### PR TITLE
Initial Unit Tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     # run only against tags
     tags:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      
+      - name: setup ignore coverage
+        run: go get github.com/hexira/go-ignore-cov && go install github.com/hexira/go-ignore-cov
+
+      - name: Run tests
+        run: go test ./... -coverprofile=coverage.out
+
+      - name: Ignore coverage
+        run: go-ignore-cov --file coverage.out
+
+      - name: Run coverage
+        run: |
+          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
+          if [ "$COVERAGE" = "100.0" ]; then
+            echo "Coverage is 100%"
+          else
+            echo "Coverage is not 100%, it is $COVERAGE%"
+            exit 1
+          fi
+
+      - name: Upload coverage
+        run: go tool cover -html=coverage.out -o coverage.html
+
+      - name: Upload coverage html
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage.html
+          path: coverage.html
+          

--- a/main.go
+++ b/main.go
@@ -1,0 +1,16 @@
+//coverage:ignore file
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	code, err := mainInternal(http.ListenAndServe)
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Exit(code)
+}

--- a/metadata-endpoint.go
+++ b/metadata-endpoint.go
@@ -35,15 +35,15 @@ func fileHandler(filename string) http.HandlerFunc {
 	}
 }
 
-func main() {
+func mainInternal(listenAndServe func(addr string, handler http.Handler) error) (int, error) {
 	vmInhostName := os.Getenv("VM_INHOST_NAME")
 	if vmInhostName == "" {
-		log.Fatal("Environment variable vm_path is not set")
+		return 1, fmt.Errorf("environment variable VM_INHOST_NAME is not set")
 	}
 
 	ipv6Address := os.Getenv("IPV6_ADDRESS")
 	if ipv6Address == "" {
-		log.Fatal("Environment variable ipv6_address is not set")
+		return 1, fmt.Errorf("environment variable IPV6_ADDRESS is not set")
 	}
 
 	certFilePath := fmt.Sprintf("/vm/%s/cert/cert.pem", vmInhostName)
@@ -55,5 +55,5 @@ func main() {
 	address := fmt.Sprintf("[%s]:8080", ipv6Address) // Format for IPv6
 
 	log.Printf("Server starting on %s...\n", address)
-	log.Fatal(http.ListenAndServe(address, nil))
+	return 0, listenAndServe(address, nil)
 }

--- a/metadata-endpoint_test.go
+++ b/metadata-endpoint_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestFileHandler(t *testing.T) {
+	handler := fileHandler("testdata/cert.pem")
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/load-balancer/cert.pem", nil))
+
+	// Assertions to check the response for cert.pem
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/load-balancer/cert.pem", nil)
+	handler = fileHandler("testdata/cert.pem")
+	handler.ServeHTTP(recorder, request)
+
+	// Check status code
+	if recorder.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, recorder.Code)
+	}
+
+	// Check response body
+	expectedData := []byte("test cert")
+
+	if !bytes.Equal(recorder.Body.Bytes(), expectedData) {
+		t.Error("Response body does not match expected content")
+	}
+
+	// Test limiter
+	for i := 0; i < 15; i++ {
+		recorder = httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, request)
+	}
+
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status code %d for rate limit exceeded, got %d", http.StatusTooManyRequests, recorder.Code)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	// Test non-existent file
+	recorder = httptest.NewRecorder()
+	handler = fileHandler("testdata/nonexistent.pem")
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Errorf("Expected status code %d for non-existent file, got %d", http.StatusNotFound, recorder.Code)
+	}
+}
+
+func TestMainInternal(t *testing.T) {
+	// Test with missing VM_INHOST_NAME
+	os.Setenv("VM_INHOST_NAME", "")
+	code, err := mainInternal(http.ListenAndServe)
+
+	if err == nil {
+		t.Error("Expected an error, got nil")
+	}
+	if code != 1 {
+		t.Errorf("Expected return code %d, got %d", 1, code)
+	}
+
+	os.Setenv("VM_INHOST_NAME", "test")
+	os.Setenv("IPV6_ADDRESS", "")
+	code, err = mainInternal(http.ListenAndServe)
+
+	if err == nil {
+		t.Error("Expected an error, got nil")
+	}
+	if code != 1 {
+		t.Errorf("Expected return code %d, got %d", 1, code)
+	}
+
+	os.Setenv("IPV6_ADDRESS", "test")
+
+	code, err = mainInternal(mockListenAndServe)
+
+	if err != nil {
+		t.Error("Expected no error, got", err)
+	}
+	if code != 0 {
+		t.Errorf("Expected return code %d, got %d", 0, code)
+	}
+
+	os.Unsetenv("VM_INHOST_NAME")
+	os.Unsetenv("IPV6_ADDRESS")
+}
+
+func mockListenAndServe(addr string, handler http.Handler) error {
+	return nil
+}

--- a/testdata/cert.pem
+++ b/testdata/cert.pem
@@ -1,0 +1,1 @@
+test cert


### PR DESCRIPTION
## Initial Unit Tests
This commit adds initial unit tests. In Go, I couldn't find a
straightforward way to test main() function. So, I have separated the
whole logic in it into a mainInternal() function and tested that. To be
able to exclude the main() function from coverage, I separated it into a
different file and added a comment to the top so that go-ignore-cov tool
picks it up to exclude.

I have added a workflow file as well so that the tests would run in
every change. We are also enforcing 100% coverage.

## Remove go-releaser run for PRs