### PR TITLE
Handle certificate unavailability with 503 and a better error message

### DIFF
--- a/metadata-endpoint.go
+++ b/metadata-endpoint.go
@@ -26,7 +26,8 @@ func fileHandler(filename string) http.HandlerFunc {
 		// Read the specified file
 		data, err := ioutil.ReadFile(filename)
 		if err != nil {
-			http.Error(w, "File not found", http.StatusNotFound)
+			w.Header().Set("Retry-After", "10")
+			http.Error(w, "Certificate not ready. Please try again in 10 seconds.", http.StatusServiceUnavailable)
 			return
 		}
 

--- a/metadata-endpoint_test.go
+++ b/metadata-endpoint_test.go
@@ -49,8 +49,8 @@ func TestFileHandler(t *testing.T) {
 	handler = fileHandler("testdata/nonexistent.pem")
 	handler.ServeHTTP(recorder, request)
 
-	if recorder.Code != http.StatusNotFound {
-		t.Errorf("Expected status code %d for non-existent file, got %d", http.StatusNotFound, recorder.Code)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Errorf("Expected status code %d for non-existent file, got %d", http.StatusServiceUnavailable, recorder.Code)
 	}
 }
 


### PR DESCRIPTION
We used to wait until the very first certificate is ready to run the metadata-endpoint daemon. However, we changed that logic in controlplane so that we can spin up this daemon immediately and communicate the state of the certificate to the user instead of just letting them send a void request.